### PR TITLE
0.8.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "device-config-schema.coffee",
     "icon.svg"
   ],
-  "version": "0.8.13",
+  "version": "0.8.14",
   "homepage": "http://github.com/pimatic/pimatic-sysinfo",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Is it possible to implement a wifi signal stregth monitor?

Within a shell sensor the command
`iwconfig wlan0`
is providing this information by signal level.
