### PR TITLE
add systemUptimeDHM and pimaticUptimeDHM

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The plugin is based on the
 * System temperature (Celsius ℃): `"temperature"`
 * System temperature (Fahrenheit ℉): `"temperatureF"`
 * System uptime in seconds: `"systemUptime"`
+* System uptime in Days Hours Minutes: `"systemUptimeDHM"`
 * WiFi received signal level (dBm): `wifiSignalLevel` 
 * Network interface throughput received (bps): `nwThroughputReceived` 
 * Network interface throughput sent (bps): `nwThroughputSent` 
@@ -29,6 +30,7 @@ The plugin is based on the
 * Pimatic process used heap memory (bytes): `"pimaticHeapUsed"`
 * Pimatic process total heap memory (bytes): `"pimaticHeapTotal"`
 * Pimatic process uptime (seconds): `"pimaticUptime"`
+* Pimatic process uptime (Days Hours Minutes): `"pimaticUptimeDHM"`
 
 Notes:
 * Database size is only applicable if builtin SQLite database

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -19,10 +19,10 @@ module.exports = {
                 "cpu", "usedMemory", "usedMemoryPercent",
                 "freeMemory", "freeMemoryPercent", "processes",
                 "temperature", "temperatureF", "dbSize",
-                "diskUsagePercent", "systemUptime", "wifiSignalLevel"
+                "diskUsagePercent", "systemUptime", "systemUptimeDHM", "wifiSignalLevel"
                 "nwThroughputReceived", "nwThroughputSent",
                 "pimaticRss", "pimaticHeapUsed",
-                "pimaticHeapTotal", "pimaticUptime",
+                "pimaticHeapTotal", "pimaticUptime", "pimaticUptimeDHM",
               ]
             interval:
               type: "integer"


### PR DESCRIPTION
I created a pull request that adds "systemUptimeDHM" and "pimaticUptimeDHM" that displays these uptimes as "days hours minutes".
When less then an hour it only displays `59 minutes`
When less than a day it displays `23 hours, 59 minutes`
When more than a day it displays ` 999 days, 23 hours, 59 minutes`

in the config.json

        {
          "name": "systemUptimeDHM",
          "interval": 120000
        },
        {
          "name": "pimaticUptimeDHM",
          "interval": 120000
        }

